### PR TITLE
removing `amsmath` from beamer example

### DIFF
--- a/source/C3.tex
+++ b/source/C3.tex
@@ -10,7 +10,6 @@
 \renewcommand\textminus{\mbox{-}}%<<<<<<<<<<<
 \begin{lstlisting}[numberstyle=\zebra{pink!15}{green!15},numbers=left,basicstyle=\footnotesize]{tex}
 \documentclass{beamer}
-\usepackage{amsmath}
 \usepackage{tcolorbox}
 \tcbuselibrary{minted,skins,breakable}
 \newtcblisting{pythoncode}[2][]{


### PR DESCRIPTION
- beamer automatically loads `amsmath`, no need to load it twice
- and even if beamer would not load it, the example does not use any macros from amsmath